### PR TITLE
Add crzy.site

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ We group projects into random categories that have absolutely nothing to do with
 
 ## 🎩 Magical Mushrooms
 
+- [crzy.site](https://crzy.site) - A growing collection of absolutely pointless single-page websites. Each one dumber than the last.
 - [tweet.md](https://tweet.md) - Replace x.com with tweet.md in any post, article or profile URL - get back clean Markdown.
 - [Touched Grass](https://www.touched-grass.com) - Show the world you've touched grass. Create your badge and share it everywhere.
 - [ConfettiSaaS](https://confettisaas.com) - Showcase your SaaS


### PR DESCRIPTION
crzy.site is a growing collection of absolutely pointless single-page websites. Each one dumber than the last. Perfect addition to the awesome list.